### PR TITLE
Remove enlive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 - A new task option `asset-host`. Used for specifying a hostname that
   will be prepended to all asset references.
+- A new task option to specify one or more file extensions to process
+  for asset-references `${...}` to replace.
 
 ## [0.1.0] - 2016-06-08
 ### Initial Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ of [keepachangelog.com](http://keepachangelog.com/).
 ## [Unreleased]
 
 [Unreleased]: https://github.com/AdamFrey/boot-asset-fingerprint/compare/0.1.0...HEAD
+### Added
+
+- A new task option `asset-host`. Used for specifying a hostname that
+  will be prepended to all asset references.
 
 ## [0.1.0] - 2016-06-08
 ### Initial Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Change Log
+All notable changes to this project will be documented in this
+file. This change log follows the conventions
+of [keepachangelog.com](http://keepachangelog.com/).
+
+
+## [Unreleased]
+
+[Unreleased]: https://github.com/AdamFrey/boot-asset-fingerprint/compare/0.1.0...HEAD
+
+## [0.1.0] - 2016-06-08
+### Initial Release
+
+- Implements an `asset-fingerprint` task for replacing references to
+  asset files with URLs containing a query-param based on the hash of
+  the contents of the file.
+
+[0.1.0]: https://github.com/AdamFrey/boot-asset-fingerprint/compare/d01ad09...0.1.0

--- a/README.org
+++ b/README.org
@@ -33,7 +33,7 @@ asset reference with the bare, unfingerprinted version.
 (deftask dev []
   (comp
     (watch)
-    (asset-fingerprint :skip true)
+    (asset-fingerprint :skip true :asset-host "http://assets.example.com")
     (target)))
 #+END_SRC
 

--- a/build.boot
+++ b/build.boot
@@ -6,7 +6,7 @@
 (require
   '[adzerk.bootlaces :as deploy])
 
-(def +version+ "1.0.0")
+(def +version+ "1.1.0-SNAPSHOT")
 
 (deploy/bootlaces! +version+)
 

--- a/build.boot
+++ b/build.boot
@@ -1,10 +1,13 @@
 (set-env!
   :source-paths #{"src"}
-  :dependencies '[[org.clojure/clojure "1.8.0" :scope "provided"]
-                  [adzerk/bootlaces "0.1.13"   :scope "test"]])
+  :dependencies '[[org.clojure/clojure "1.8.0"  :scope "provided"]
+                  [boot/core           "2.1.0"  :scope "provided"]
+                  [adzerk/bootlaces    "0.1.13" :scope "test"]
+                  [adzerk/boot-test    "1.1.2"  :scope "test"]])
 
 (require
-  '[adzerk.bootlaces :as deploy])
+ '[adzerk.bootlaces :as deploy]
+ '[adzerk.boot-test :as boot-test])
 
 (def +version+ "1.1.0-SNAPSHOT")
 
@@ -22,6 +25,20 @@
   (comp
     (watch)
     (deploy/build-jar)))
+
+(deftask development []
+  (merge-env! :source-paths ["test"])
+  identity)
+
+;;; This prevents a name collision WARNING between the test task and
+;;; clojure.core/test, a function that nobody really uses or cares
+;;; about.
+(ns-unmap 'boot.user 'test)
+
+(deftask test []
+  (comp
+   (development)
+   (boot-test/test)))
 
 (deftask push-release []
   (comp

--- a/example/build.boot
+++ b/example/build.boot
@@ -1,7 +1,7 @@
 (set-env!
   :resource-paths #{"resources"}
   :dependencies '[[org.clojure/clojure "1.8.0"]
-                  [afrey/boot-asset-fingerprint "1.0.0"]
+                  [afrey/boot-asset-fingerprint "1.1.0-SNAPSHOT"]
                   [tailrecursion/boot-jetty "0.1.3" :scope "test"]])
 
 (require
@@ -11,6 +11,7 @@
 (deftask dev []
   (comp
     (watch)
-    (asset-fingerprint)
+    (asset-fingerprint :extension [".css"])
+    (asset-fingerprint :extension [".html"])
     (jetty/serve :port 5000)
     (target)))

--- a/src/afrey/boot_asset_fingerprint.clj
+++ b/src/afrey/boot_asset_fingerprint.clj
@@ -6,9 +6,6 @@
             [boot.task.built-in :as built-in]
             [clojure.java.io :as io]))
 
-(defn- pod-deps []
-  (remove pod/dependency-loaded? '[[enlive "1.1.6"]]))
-
 (defn- pod-init
   [fresh-pod]
   (pod/with-eval-in fresh-pod
@@ -24,11 +21,10 @@
 
 (core/deftask asset-fingerprint
   "Fingerprint files in a pod"
-  [s skip bool "Skips file fingerprinting and replaces each asset url with bare TODO"]
+  [s skip bool "Skips file fingerprinting and replaces each asset url with bare"]
 
   (let [prev        (atom nil)
-        updated-env (update (core/get-env) :dependencies into (pod-deps))
-        pods        (pod/pod-pool updated-env :init pod-init)
+        pods        (pod/pod-pool (core/get-env) :init pod-init)
         tmp-dir     (core/tmp-dir!)]
     (core/cleanup (pods :shutdown))
     (core/with-pre-wrap fileset

--- a/src/afrey/boot_asset_fingerprint.clj
+++ b/src/afrey/boot_asset_fingerprint.clj
@@ -21,7 +21,13 @@
   (or (-> path io/file .getParent) ""))
 
 (core/deftask asset-fingerprint
-  "Fingerprint files in a pod"
+  "Replace asset references with a URL query-parameter based on the hash contents.
+
+  The main purpose of doing this is for cache-busting static assets
+  that were deployed with a far-future expiration date. See the Ruby
+  on Rails Asset Pipeline guide, segment \"What is Fingerprinting and
+  Why Should I Care\" for a detailed explanation of why you want to do this.
+  (http://guides.rubyonrails.org/asset_pipeline.html#what-is-fingerprinting-and-why-should-i-care-questionmark) "
   [s skip            bool  "Skips file fingerprinting and replaces each asset url with bare"
    e extensions  EXT  [str] "Add a file extension to indicate the files to process for asset references."
    _ asset-host HOST str   "Host to prefix all asset urls with"

--- a/src/afrey/boot_asset_fingerprint.clj
+++ b/src/afrey/boot_asset_fingerprint.clj
@@ -21,8 +21,9 @@
 
 (core/deftask asset-fingerprint
   "Fingerprint files in a pod"
-  [s skip bool "Skips file fingerprinting and replaces each asset url with bare"]
-
+  [s skip            bool  "Skips file fingerprinting and replaces each asset url with bare"
+   e extension  EXT  [str] "Add a file extension to indicate the files to process for asset references."
+   ]
   (let [prev        (atom nil)
         pods        (pod/pod-pool (core/get-env) :init pod-init)
         tmp-dir     (core/tmp-dir!)]
@@ -48,7 +49,8 @@
                 ~{:input-path  input-path
                   :input-root  input-root
                   :output-path output-path
-                  :skip        skip
+                  :fingerprint? (not skip)
+                  :asset-host asset-host
                   :file-hashes file-hashes}))))
 
         (-> fileset (core/add-resource tmp-dir) core/commit!)))))

--- a/src/afrey/boot_asset_fingerprint.clj
+++ b/src/afrey/boot_asset_fingerprint.clj
@@ -45,7 +45,7 @@
                       output-path (-> (io/file tmp-dir path) .getPath)
                       input-root (path->parent-path path)]]
           (do
-            (util/info (format "Fingerprinting %s...\n" path))
+            (util/info "Fingerprinting %s...\n" path)
             (pod/with-eval-in worker-pod
               (afrey.boot-asset-fingerprint.impl/fingerprint
                 ~{:input-path  input-path

--- a/src/afrey/boot_asset_fingerprint/impl.clj
+++ b/src/afrey/boot_asset_fingerprint/impl.clj
@@ -1,6 +1,6 @@
 (ns afrey.boot-asset-fingerprint.impl
-  (:require [net.cgrand.enlive-html :as html]
-            [clojure.java.io :as io]))
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]))
 
 (defn asset-full-path
   "Return the full path of an asset, taking into account relative and absolute paths.
@@ -26,23 +26,17 @@
     (str asset-path "?v=" fingerprint)
     asset-path))
 
-(defn template [input-file {:keys [skip file-hashes input-root]}]
-  (html/template (html/html-resource input-file)
-    []
-    [html/any-node]
-    (html/replace-vars
-      (fn [asset-name]
-        (let [asset-path (subs (str asset-name) 1)]
-          (if skip
-            asset-path
+(defn lookup-fn [{:keys [skip file-hashes input-root]}]
+  (fn [[_ asset-path]]
+    (if skip
+      asset-path
 
-            (let [full-path (asset-full-path asset-path input-root)
-                  fingerprint (get file-hashes full-path)]
-              (fingerprint-asset asset-path fingerprint))))))))
-
+      (let [full-path (asset-full-path (str asset-path) input-root)
+            fingerprint (get file-hashes full-path)]
+        (fingerprint-asset asset-path fingerprint)))))
 
 (defn fingerprint
   [{:keys [input-path output-path] :as opts}]
   (let [out (io/file output-path)]
     (io/make-parents out)
-    (spit out (reduce str ((template (io/file input-path) opts))))))
+    (spit out (str/replace (slurp input-path) #"\$\{(.+?)\}" (lookup-fn opts)))))

--- a/src/afrey/boot_asset_fingerprint/impl.clj
+++ b/src/afrey/boot_asset_fingerprint/impl.clj
@@ -13,13 +13,15 @@
 
   [path relative-root]
   (let [separator (java.io.File/separator)]
-    (if (= (subs path 0 1) separator)
-      ;; absolute path
+    (cond
+      (= (subs path 0 1) separator)
       (subs path 1)
-      ;; relative path
-      (if (empty? relative-root)
-        path
-        (str relative-root separator path)))))
+
+      (empty? relative-root)
+      path
+
+      :else
+      (str relative-root separator path))))
 
 (defn fingerprint-asset [asset-path fingerprint]
   (if fingerprint

--- a/test/afrey/boot_asset_fingerprint/impl_test.clj
+++ b/test/afrey/boot_asset_fingerprint/impl_test.clj
@@ -14,3 +14,25 @@
            "foo.txt"))
     (is (= (asset-full-path "foo.txt" "parent")
            "parent/foo.txt"))))
+
+(deftest test-fingerprint-asset
+  (is (= (fingerprint-asset "/foo.txt" {:file-hashes {}})
+         "/foo.txt"))
+  (is (= (fingerprint-asset "/foo.txt" {:file-hashes {"foo.txt" "barbaz"}})
+         "/foo.txt?v=barbaz")))
+
+(deftest test-prepend-asset-host
+  (testing "skip when no asset-host is given"
+    (is (= (prepend-asset-host "/foo.txt" nil)
+           "/foo.txt"))
+
+    (is (= (prepend-asset-host "/foo.txt" "")
+           "/foo.txt")))
+
+  (testing "prepend the asset host with only one separating slash"
+    (is (= (prepend-asset-host "/foo.txt" "assets.example.org")
+           "assets.example.org/foo.txt")))
+
+  (testing "drops a possible trailing slash on the asset host"
+    (is (= (prepend-asset-host "/foo.txt" "assets.example.org/")
+           "assets.example.org/foo.txt"))))

--- a/test/afrey/boot_asset_fingerprint/impl_test.clj
+++ b/test/afrey/boot_asset_fingerprint/impl_test.clj
@@ -1,0 +1,16 @@
+(ns afrey.boot-asset-fingerprint.impl-test
+  (:require [clojure.test :refer :all]
+            [afrey.boot-asset-fingerprint.impl :refer :all]))
+
+(deftest test-asset-full-path
+  (testing "absolute paths"
+    (is (= (asset-full-path "/foo.txt" "")
+           "foo.txt"))
+    (is (= (asset-full-path "/foo.txt" "parent")
+           "foo.txt")))
+
+  (testing "relative paths"
+    (is (= (asset-full-path "foo.txt" "")
+           "foo.txt"))
+    (is (= (asset-full-path "foo.txt" "parent")
+           "parent/foo.txt"))))


### PR DESCRIPTION
Hey, this PR removes the Enlive dependency and adds two task options:

- `asset-host` which allows the user to specify an specific host to prefix asset URLs with
- `extensions` which allows the user to specify the list of file extensions to process for asset references.

Both of these new options default to the previous behavior, so unless the behavior of the task should not change unless they are passed.

I also added a change log and documented the changes I made, and cleaned up a few random things.

Fixes #1 
