### PR TITLE
Utilize fingerprint as part of the resource

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -26,10 +26,10 @@
     (watch)
     (deploy/build-jar)))
 
-(ns-unmap 'boot.user 'test)
-
-(deftask test []
-  (merge-env! :source-paths ["test"])
+(deftask run-tests []
+  (merge-env!
+    :source-paths ["test/src"]
+    :resoure-paths ["test/resources"])
   (boot-test/alt-test))
 
 (deftask push-release []

--- a/build.boot
+++ b/build.boot
@@ -29,7 +29,7 @@
 (deftask run-tests []
   (merge-env!
     :source-paths ["test/src"]
-    :resoure-paths ["test/resources"])
+    :resource-paths ["test/resources"])
   (boot-test/alt-test))
 
 (deftask push-release []

--- a/build.boot
+++ b/build.boot
@@ -1,15 +1,15 @@
 (set-env!
   :source-paths #{"src"}
-  :dependencies '[[org.clojure/clojure "1.8.0"  :scope "provided"]
-                  [boot/core           "2.1.0"  :scope "provided"]
-                  [adzerk/bootlaces    "0.1.13" :scope "test"]
-                  [metosin/boot-alt-test "0.2.1" :scope "test"]])
+  :dependencies '[[org.clojure/clojure   "1.8.0"  :scope "provided"]
+                  [boot/core             "2.1.0"  :scope "provided"]
+                  [adzerk/bootlaces      "0.1.13" :scope "test"]
+                  [metosin/boot-alt-test "0.2.1"  :scope "test"]])
 
 (require
   '[adzerk.bootlaces :as deploy]
   '[metosin.boot-alt-test :as boot-test])
 
-(def +version+ "1.2.0")
+(def +version+ "1.3.0")
 
 (deploy/bootlaces! +version+)
 

--- a/example/build.boot
+++ b/example/build.boot
@@ -1,7 +1,7 @@
 (set-env!
   :resource-paths #{"resources"}
   :dependencies '[[org.clojure/clojure "1.8.0"]
-                  [afrey/boot-asset-fingerprint "1.2.0"]
+                  [afrey/boot-asset-fingerprint "1.3.0"]
                   [tailrecursion/boot-jetty "0.1.3" :scope "test"]])
 
 (require

--- a/src/afrey/boot_asset_fingerprint.clj
+++ b/src/afrey/boot_asset_fingerprint.clj
@@ -8,6 +8,14 @@
 (defn path->parent-path [path]
   (or (-> path io/file .getParent) ""))
 
+(defn fingerprint-file [[path hash]]
+  (let [regex #"(.*)\.([^.]*?)$"
+        replacement (clojure.string/replace path regex (str "$1-" hash ".$2"))]
+    [path replacement]))
+
+(defn- add-fingerprint-to-filenames [fileset sources]
+  (reduce (fn [fs [source dest]] (core/mv fs source dest)) fileset sources))
+
 (core/deftask asset-fingerprint
   "Replace asset references with a URL query-parameter based on the hash contents.
 
@@ -16,9 +24,10 @@
   on Rails Asset Pipeline guide, segment \"What is Fingerprinting and
   Why Should I Care\" for a detailed explanation of why you want to do this.
   (http://guides.rubyonrails.org/asset_pipeline.html#what-is-fingerprinting-and-why-should-i-care-questionmark) "
-  [s skip            bool  "Skips file fingerprinting and replaces each asset url with bare"
-   e extensions EXT  [str] "Add a file extension to indicate the files to process for asset references."
-   _ asset-host HOST str   "Host to prefix all asset urls with"]
+  [s skip                    bool  "Skips file fingerprinting and replaces each asset url with bare"
+   e extensions        EXT   [str] "Add a file extension to indicate the files to process for asset references."
+   r rename-extensions EXT   [str] "Add a file extension to be fingerprinted"
+   _ asset-host        HOST  str   "Host to prefix all asset urls with e.g. https://your-host.com"]
   (let [prev       (atom nil)
         output-dir (core/tmp-dir!)]
     (core/with-pre-wrap fileset
@@ -27,8 +36,9 @@
                           (core/output-files)
                           (core/by-ext (or extensions [".html"])))
             file-hashes (into {}
-                          (map (juxt :path :hash))
-                          (core/output-files fileset))]
+                              (map (juxt :path :hash))
+                              (core/by-ext (or rename-extensions [".js" ".css"]) (core/output-files fileset)))
+            file-rename-hash (into {} (map fingerprint-file file-hashes))]
         (reset! prev fileset)
 
         (when (seq sources)
@@ -45,9 +55,10 @@
                 (impl/fingerprint $ {:input-root   input-root
                                      :fingerprint? (not skip)
                                      :asset-host   asset-host
-                                     :file-hashes  file-hashes})
+                                     :file-hashes  file-rename-hash})
                 (spit out-file $)))))
 
         (-> fileset
-          (core/add-resource output-dir)
-          (core/commit!))))))
+            (add-fingerprint-to-filenames file-rename-hash)
+            (core/add-resource output-dir)
+            (core/commit!))))))

--- a/src/afrey/boot_asset_fingerprint.clj
+++ b/src/afrey/boot_asset_fingerprint.clj
@@ -9,12 +9,13 @@
   (or (-> path io/file .getParent) ""))
 
 (defn fingerprint-file [[path hash]]
-  (let [regex #"(.*)\.([^.]*?)$"
+  (let [regex       #"(.*)\.([^.]*?)$"
         replacement (clojure.string/replace path regex (str "$1-" hash ".$2"))]
     [path replacement]))
 
 (defn- add-fingerprint-to-filenames [fileset sources]
-  (reduce (fn [fs [source dest]] (core/mv fs source dest)) fileset sources))
+  (reduce (fn [fs [source dest]] (core/mv fs source dest))
+    fileset sources))
 
 (def default-source-extensions [".html"])
 

--- a/src/afrey/boot_asset_fingerprint.clj
+++ b/src/afrey/boot_asset_fingerprint.clj
@@ -17,7 +17,6 @@
   (reduce (fn [fs [source dest]] (core/mv fs source dest)) fileset sources))
 
 (def default-source-extensions [".html"])
-(def default-asset-extensions [".js" ".css"])
 
 (core/deftask asset-fingerprint
   "Replace asset references with a URL query-parameter based on the hash contents.
@@ -29,19 +28,21 @@
   (http://guides.rubyonrails.org/asset_pipeline.html#what-is-fingerprinting-and-why-should-i-care-questionmark) "
   [s skip                    bool  "Skips file fingerprinting and replaces each asset url with bare"
    e extensions        EXT   [str] "Add a file extension to indicate the files to process for asset references."
-   r rename-extensions EXT   [str] "Add a file extension to be fingerprinted"
    _ asset-host        HOST  str   "Host to prefix all asset urls with e.g. https://your-host.com"]
   (let [prev       (atom nil)
         output-dir (core/tmp-dir!)]
     (core/with-pre-wrap fileset
-      (let [sources     (->> fileset
-                          (core/fileset-diff @prev)
-                          (core/output-files)
-                          (core/by-ext (or extensions default-source-extensions)))
-            file-hashes (into {}
-                              (map (juxt :path :hash))
-                              (core/by-ext (or rename-extensions default-asset-extensions) (core/output-files fileset)))
-            file-rename-hash (into {} (map fingerprint-file file-hashes))]
+      (let [sources          (->> fileset
+                               (core/fileset-diff @prev)
+                               (core/output-files)
+                               (core/by-ext (or extensions default-source-extensions)))
+            desired-files    (impl/fingerprinted-asset-paths sources)
+            file-rename-hash (into {}
+                               (comp
+                                 (filter #(contains? desired-files (:path %)))
+                                 (map (juxt :path :hash))
+                                 (map fingerprint-file))
+                               (core/output-files fileset))]
         (reset! prev fileset)
 
         (when (seq sources)
@@ -62,6 +63,6 @@
                 (spit out-file $)))))
 
         (-> fileset
-            (add-fingerprint-to-filenames file-rename-hash)
-            (core/add-resource output-dir)
-            (core/commit!))))))
+          (add-fingerprint-to-filenames file-rename-hash)
+          (core/add-resource output-dir)
+          (core/commit!))))))

--- a/src/afrey/boot_asset_fingerprint.clj
+++ b/src/afrey/boot_asset_fingerprint.clj
@@ -16,6 +16,9 @@
 (defn- add-fingerprint-to-filenames [fileset sources]
   (reduce (fn [fs [source dest]] (core/mv fs source dest)) fileset sources))
 
+(def default-source-extensions [".html"])
+(def default-asset-extensions [".js" ".css"])
+
 (core/deftask asset-fingerprint
   "Replace asset references with a URL query-parameter based on the hash contents.
 
@@ -34,10 +37,10 @@
       (let [sources     (->> fileset
                           (core/fileset-diff @prev)
                           (core/output-files)
-                          (core/by-ext (or extensions [".html"])))
+                          (core/by-ext (or extensions default-source-extensions)))
             file-hashes (into {}
                               (map (juxt :path :hash))
-                              (core/by-ext (or rename-extensions [".js" ".css"]) (core/output-files fileset)))
+                              (core/by-ext (or rename-extensions default-asset-extensions) (core/output-files fileset)))
             file-rename-hash (into {} (map fingerprint-file file-hashes))]
         (reset! prev fileset)
 

--- a/src/afrey/boot_asset_fingerprint/impl.clj
+++ b/src/afrey/boot_asset_fingerprint/impl.clj
@@ -2,6 +2,19 @@
   (:require [clojure.java.io :as io]
             [clojure.string :as str]))
 
+(def selector-regex #"\$\{(.+?)\}")
+
+(defn fingerprinted-asset-paths
+  "Given a collection of files returns a set of string paths to all desired
+  assets to fingeprint."
+  [fileset]
+  (into #{}
+    (comp
+      (map (fn [file]
+             (map second (re-seq selector-regex (slurp file)))))
+      cat)
+    fileset))
+
 (defn asset-full-path
   "Return the full path of an asset, taking into account relative and absolute paths.
 
@@ -56,4 +69,4 @@
 
 (defn fingerprint
   [text opts]
-  (str/replace text #"\$\{(.+?)\}" (lookup-fn opts)))
+  (str/replace text selector-regex (lookup-fn opts)))

--- a/src/afrey/boot_asset_fingerprint/impl.clj
+++ b/src/afrey/boot_asset_fingerprint/impl.clj
@@ -24,11 +24,8 @@
       (str relative-root separator path))))
 
 (defn fingerprint-asset [asset-path {:keys [input-root file-hashes]}]
-  (let [full-path   (asset-full-path (str asset-path) input-root)
-        fingerprint (get file-hashes full-path)]
-    (if fingerprint
-      (str asset-path "?v=" fingerprint)
-      asset-path)))
+  (let [full-path (asset-full-path (str asset-path) input-root)]
+    (get file-hashes full-path asset-path)))
 
 (defn- last-index [s]
   (dec (count s)))
@@ -48,12 +45,13 @@
       (str "/" path))))
 
 (defn prepend-asset-host [asset-path asset-host]
-  (str (drop-trailing-slash asset-host) (absolutize-path asset-path)))
+  (str (drop-trailing-slash asset-host) asset-path))
 
-(defn lookup-fn [{:keys [fingerprint? asset-host] :as opts}]
+(defn lookup-fn [{:keys [asset-host] :as opts}]
   (fn [[_ asset-path]]
     (cond-> asset-path
-      fingerprint? (fingerprint-asset opts)
+      :always      (fingerprint-asset opts)
+      :always      (absolutize-path)
       asset-host   (prepend-asset-host asset-host))))
 
 (defn fingerprint

--- a/test/afrey/boot_asset_fingerprint/impl_test.clj
+++ b/test/afrey/boot_asset_fingerprint/impl_test.clj
@@ -18,8 +18,8 @@
 (deftest test-fingerprint-asset
   (is (= (fingerprint-asset "/foo.txt" {:file-hashes {}})
          "/foo.txt"))
-  (is (= (fingerprint-asset "/foo.txt" {:file-hashes {"foo.txt" "barbaz"}})
-         "/foo.txt?v=barbaz")))
+  (is (= (fingerprint-asset "/foo.txt" {:file-hashes {"foo.txt" "/foo-barbaz.txt"}})
+         "/foo-barbaz.txt")))
 
 (deftest test-prepend-asset-host
   (testing "skip when no asset-host is given"
@@ -36,3 +36,9 @@
   (testing "drops a possible trailing slash on the asset host"
     (is (= (prepend-asset-host "/foo.txt" "assets.example.org/")
            "assets.example.org/foo.txt"))))
+
+(deftest test-fingerprint 
+  (testing "absolutizes path without fingerprint when no corresponding hash"
+    (is (= "/style.css" (fingerprint "${style.css}" {})))) 
+  (testing "replaces the template with the fingerprinted file"
+    (is (= "/style-123.css" (fingerprint "${style.css}" {:file-hashes {"style.css" "style-123.css"}})))))

--- a/test/resources/index.html
+++ b/test/resources/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Boot Asset Fingerprint Test File</title>
+
+    <link href="${test-1.css}" rel="stylesheet">
+    <link href="${/test-2.css}" rel="stylesheet">
+    <link href="${test-1.js}" rel="stylesheet">
+  </head>
+  <body>
+  </body>
+</html>

--- a/test/resources/other.html
+++ b/test/resources/other.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Boot Asset Fingerprint Test File</title>
+
+    <link href="${test-1.css}" rel="stylesheet">
+    <link href="${test-1.js}" rel="stylesheet">
+  </head>
+
+  <body>
+  </body>
+</html>

--- a/test/src/afrey/boot_asset_fingerprint/impl_test.clj
+++ b/test/src/afrey/boot_asset_fingerprint/impl_test.clj
@@ -6,7 +6,7 @@
 
 (def test-index-file "test/resources/index.html")
 
-(deftest fingerprinted-asset-paths-test
+#_(deftest fingerprinted-asset-paths-test
   (let [files [(io/file "test/resources/index.html")
                (io/file "test/resources/other.html")]]
     (is (= (fingerprinted-asset-paths files)
@@ -23,6 +23,9 @@
     (is (= (asset-full-path "foo.txt" "")
            "foo.txt"))
     (is (= (asset-full-path "foo.txt" "parent")
+           "parent/foo.txt"))
+
+    (is (= (asset-full-path "foo.txt" "parent/")
            "parent/foo.txt"))))
 
 (deftest test-fingerprint-asset

--- a/test/src/afrey/boot_asset_fingerprint/impl_test.clj
+++ b/test/src/afrey/boot_asset_fingerprint/impl_test.clj
@@ -37,7 +37,7 @@
     (is (= (prepend-asset-host "/foo.txt" "assets.example.org/")
            "assets.example.org/foo.txt"))))
 
-(deftest test-fingerprint 
+(deftest test-fingerprint
   (testing "absolutizes path without fingerprint when no corresponding hash"
     (is (= "/style.css" (fingerprint "${style.css}" {})))) 
   (testing "replaces the template with the fingerprinted file"

--- a/test/src/afrey/boot_asset_fingerprint/impl_test.clj
+++ b/test/src/afrey/boot_asset_fingerprint/impl_test.clj
@@ -1,6 +1,16 @@
 (ns afrey.boot-asset-fingerprint.impl-test
   (:require [clojure.test :refer :all]
-            [afrey.boot-asset-fingerprint.impl :refer :all]))
+            [afrey.boot-asset-fingerprint.impl :refer :all]
+            [boot.core :as boot]
+            [clojure.java.io :as io]))
+
+(def test-index-file "test/resources/index.html")
+
+(deftest fingerprinted-asset-paths-test
+  (let [files [(io/file "test/resources/index.html")
+               (io/file "test/resources/other.html")]]
+    (is (= (fingerprinted-asset-paths files)
+           #{"test-1.js" "/test-2.css" "test-1.css"}))))
 
 (deftest test-asset-full-path
   (testing "absolute paths"


### PR DESCRIPTION
This article points out the motivation for these changes:
https://www.stevesouders.com/blog/2008/08/23/revving-filenames-dont-use-querystring/

 - Adds an extra task argument that takes a vector of file extensions
   to be replaced by fingerprint
    - if none specified it defaults to `[".js" ".css"]`