### PR TITLE
Asset root support

### DIFF
--- a/example/resources/nested/index.html
+++ b/example/resources/nested/index.html
@@ -9,6 +9,6 @@
 
   <body>
     <p>Nested</p>
-    <script src="${nested.js}"></script>
+    <script src="${nested/nested.js}"></script>
   </body>
 </html>

--- a/test/src/afrey/boot_asset_fingerprint/impl_test.clj
+++ b/test/src/afrey/boot_asset_fingerprint/impl_test.clj
@@ -52,6 +52,6 @@
 
 (deftest test-fingerprint
   (testing "absolutizes path without fingerprint when no corresponding hash"
-    (is (= "/style.css" (fingerprint "${style.css}" {})))) 
+    (is (= "/style.css" (update-asset-references "${style.css}" {}))))
   (testing "replaces the template with the fingerprinted file"
-    (is (= "/style-123.css" (fingerprint "${style.css}" {:file-hashes {"style.css" "style-123.css"}})))))
+    (is (= "/style-123.css" (update-asset-references "${style.css}" {:file-hashes {"style.css" "style-123.css"}})))))


### PR DESCRIPTION
Fixes #4.

The path of the source file was being concatenated onto the asset path,
which is incorrect when the root dir is common. For example, `full-asset-path`
returned the path `public/css/img/background.png`, later failing when the
references were replaced.

The change I've introduced is breaking, since now all templated references are
relative to the asset root. In the example directory, the reference
`${nested.js}` inside `nested/index.html` is now `${nested/nested.js}`. I think
this makes more sense because assets are typically served from a single
directory; it's far easier to remember the asset root than the path of the asset
relative to the source file. There may, however, be something I've not
considered - happy to make changes if necessary.